### PR TITLE
Use more env vars + minor comment fix

### DIFF
--- a/doctolib_monitor.py
+++ b/doctolib_monitor.py
@@ -12,9 +12,9 @@ TELEGRAM_BOT_TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
 TELEGRAM_CHAT_ID = os.getenv('TELEGRAM_CHAT_ID')
 
 # Your doctor-specific URLs and settings
-BOOKING_URL = os.getenv('BOOKING_URL')
-AVAILABILITIES_URL = os.getenv('AVAILABILITIES_URL')
-APPOINTMENT_NAME = os.getenv('APPOINTMENT_NAME')
+BOOKING_URL = os.getenv('BOOKING_URL') # Example: 'https://www.doctolib.de/facharzt-fur-humangenetik/berlin/annechristin-meiner/booking/availabilities?specialityId=1305&telehealth=false&placeId=practice-207074&insuranceSectorEnabled=true&insuranceSector=public&isNewPatient=false&isNewPatientBlocked=false&motiveIds[]=5918040&pid=practice-207074&bookingFunnelSource=profile'
+AVAILABILITIES_URL = os.getenv('AVAILABILITIES_URL') # Example: 'https://www.doctolib.de/availabilities.json?visit_motive_ids=5918040&agenda_ids=529392&practice_ids=207074&insurance_sector=public&telehealth=false&start_date=2025-07-09&limit=5'
+APPOINTMENT_NAME = os.getenv('APPOINTMENT_NAME') # Example: 'Dr. Annechristin Meiner'
 MOVE_BOOKING_URL = None
 
 # Updated settings - monitor 3 months ahead for specialist appointments

--- a/doctolib_monitor.py
+++ b/doctolib_monitor.py
@@ -12,14 +12,14 @@ TELEGRAM_BOT_TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
 TELEGRAM_CHAT_ID = os.getenv('TELEGRAM_CHAT_ID')
 
 # Your doctor-specific URLs and settings
-BOOKING_URL = 'https://www.doctolib.de/facharzt-fur-humangenetik/berlin/annechristin-meiner/booking/availabilities?specialityId=1305&telehealth=false&placeId=practice-207074&insuranceSectorEnabled=true&insuranceSector=public&isNewPatient=false&isNewPatientBlocked=false&motiveIds[]=5918040&pid=practice-207074&bookingFunnelSource=profile'
-AVAILABILITIES_URL = 'https://www.doctolib.de/availabilities.json?visit_motive_ids=5918040&agenda_ids=529392&practice_ids=207074&insurance_sector=public&telehealth=false&start_date=2025-07-09&limit=5'
-APPOINTMENT_NAME = 'Dr. Annechristin Meiner'
+BOOKING_URL = os.getenv('BOOKING_URL')
+AVAILABILITIES_URL = os.getenv('AVAILABILITIES_URL')
+APPOINTMENT_NAME = os.getenv('APPOINTMENT_NAME')
 MOVE_BOOKING_URL = None
 
 # Updated settings - monitor 3 months ahead for specialist appointments
 UPCOMING_DAYS = 15  # Maximum per API call (Doctolib's limit)
-TOTAL_DAYS_TO_MONITOR = 120  # 3 months total coverage
+TOTAL_DAYS_TO_MONITOR = 120  # 4 months total coverage
 MAX_DATETIME_IN_FUTURE = datetime.today() + timedelta(days = TOTAL_DAYS_TO_MONITOR)
 NOTIFY_HOURLY = False
 


### PR DESCRIPTION
I'm happily using your script, thanks!
I deployed it as Kubernetes CronJob in a self-hosted kubernetes cluster, using python:3.13.5-alpine3.22 docker image
Seems to work well.

I followed the instructions from https://github.com/mayrs/der-bergdoktorbot-a-doctolib-doctors-appointment-telegram-notifier to prepare the Telegram bot: it would probably be worth documenting it here, too.

This PR simply avoids some hardcoded values